### PR TITLE
[fix] Fix scroll on newer versions of Chrome (>=61) + remove unused code

### DIFF
--- a/css.js
+++ b/css.js
@@ -1,2 +1,0 @@
-exports.aceEditorCSS = function(hook_name, cb){return ["/ep_cursortrace/static/css/cursortrace.css"];} // inner pad CSS
-

--- a/ep.json
+++ b/ep.json
@@ -5,7 +5,6 @@
       "client_hooks": {
         "aceEditorCSS": "ep_cursortrace/static/js/css",
         "aceInitInnerdocbodyHead": "ep_cursortrace/static/js/main:aceInitInnerdocbodyHead",
-        "aceInitialized": "ep_cursortrace/static/js/main:aceInitialized",
         "postAceInit": "ep_cursortrace/static/js/main:postAceInit",
         "aceEditEvent": "ep_cursortrace/static/js/main:aceEditEvent",
         "handleClientMessage_CUSTOM": "ep_cursortrace/static/js/main",

--- a/handleMessage.js
+++ b/handleMessage.js
@@ -10,20 +10,20 @@ padMessageHandler = require("ep_etherpad-lite/node/handler/PadMessageHandler"),
 
 var buffer = {};
 
-/* 
+/*
 * Handle incoming messages from clients
 */
 exports.handleMessage = function(hook_name, context, callback){
   // Firstly ignore any request that aren't about cursor
   var iscursorMessage = false;
   if(context){
-    if(context.message && context.message){
+    if(context.message){
       if(context.message.type === 'COLLABROOM'){
-        if(context.message.data){ 
+        if(context.message.data){
           if(context.message.data.type){
             if(context.message.data.type === 'cursor'){
               iscursorMessage = true;
-            } 
+            }
           }
         }
       }
@@ -48,7 +48,7 @@ exports.handleMessage = function(hook_name, context, callback){
 
       var msg = {
         type: "COLLABROOM",
-        data: { 
+        data: {
           type: "CUSTOM",
           payload: {
             action: "cursorPosition",
@@ -64,11 +64,7 @@ exports.handleMessage = function(hook_name, context, callback){
     });
   }
 
-  if(iscursorMessage === true){
-    callback([null]);
-  }else{
-    callback(true);
-  }
+  callback([null]);
 }
 
 


### PR DESCRIPTION
Newer versions of Chrome use the same way of Firefox to handle scrolling.

Also remove some trailing spaces.